### PR TITLE
ensure that the member and guild exists, and check that they canManage

### DIFF
--- a/src/routes/oauthGuilds.js
+++ b/src/routes/oauthGuilds.js
@@ -12,12 +12,29 @@ module.exports = class extends Route {
 
 	async post(request, response) {
 		const botGuild = this.client.guilds.get(request.body.id);
+		const member = await botGuild.members.fetch(request.auth.scope[0]);
+		const canManage = member.permissions.has('MANAGE_GUILD');
+
+		if (!member || !botGuild) this.notFound(response);
+
+		if (!canManage) return this.unauthorized(response);
+
 		const updated = await botGuild.settings.update(request.body.data, { action: 'overwrite' });
 		const errored = Boolean(updated.errors.length);
 
 		if (errored) this.client.emit('error', `${botGuild.name}[${botGuild.id}] failed updating guild configs via dashboard with error:\n${inspect(updated.errors)}`);
 
 		return response.end(RESPONSES.UPDATED[Number(!errored)]);
+	}
+
+	unauthorized(response) {
+		response.writeHead(401);
+		return response.end(RESPONSES.UNAUTHORIZED);
+	}
+
+	notFound(response) {
+		response.writeHead(404);
+		return response.end(RESPONSES.NOT_FOUND);
 	}
 
 };

--- a/src/routes/oauthGuilds.js
+++ b/src/routes/oauthGuilds.js
@@ -1,4 +1,5 @@
 const { Route, constants: { RESPONSES } } = require('klasa-dashboard-hooks');
+const { Permissions: { FLAGS: { MANAGE_GUILD } } } = require('discord.js');
 const { inspect } = require('util');
 
 module.exports = class extends Route {
@@ -12,11 +13,10 @@ module.exports = class extends Route {
 
 	async post(request, response) {
 		const botGuild = this.client.guilds.get(request.body.id);
-		const member = await botGuild.members.fetch(request.auth.scope[0]);
-		const canManage = member.permissions.has('MANAGE_GUILD');
+		const member = await botGuild.members.fetch(request.auth.scope[0]).catch(() => null);
 
-		if (!member || !botGuild) this.notFound(response);
-
+		if (!member || !botGuild) return this.notFound(response);
+		const canManage = member.permissions.has(MANAGE_GUILD);
 		if (!canManage) return this.unauthorized(response);
 
 		const updated = await botGuild.settings.update(request.body.data, { action: 'overwrite' });


### PR DESCRIPTION
### Description of the PR

This fixes a security hole where a user can authenticate, and then lose `MANAGE_SERVER` permissions in a server, but the server will still trust that their scope says they can manage it. It also will throw a `404 - Not Found` error if the guild/user is not found, its possible the guild is deleted after authentication (while still in the scope).

There is some code dupe with the `unauthorized` and `notFound` methods of the route, I couldn't think of a good and clean way to centralize the error handling. Perhaps the `Route` and `Middleware` base classes can have a `error` method which would be used like this: `this.error(404, RESPONSES.NOT_FOUND);`, or `this.error(404);` if the response message will be the same every time for each error code.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
