### PR TITLE
handle JSON.parse errors

### DIFF
--- a/src/middlewares/json.js
+++ b/src/middlewares/json.js
@@ -15,8 +15,12 @@ module.exports = class extends Middleware {
 
 		for await (const chunk of stream) body += chunk;
 
-		const data = JSON.parse(body);
-		request.body = data;
+		try {
+			const data = JSON.parse(body);
+			request.body = data;
+		} catch (err) {
+			request.body = {};
+		}
 	}
 
 	contentStream(request) {


### PR DESCRIPTION
### Description of the PR
`JSON.parse` here can fail, you can never trust what users can send, i have an error logger that sends error to a discord channel and everyday I'm flooded with JSON SyntaxErrors coming from this middleware this PR handles it and if parsing fails keep it an empty object to prevent undefined errors.

I would also like to note the gzip part can even fail too if they send invalid gzip but I'm not sure how i should handle that one properly since I'm not experienced with streams.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- adds `try/catch` to the `JSON.parse` call

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
