### PR TITLE
typings: Augment discord.js and klasa

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -185,6 +185,7 @@ declare module 'discord.js' {
 
 	export interface ClientOptions {
 		dashboardHooks?: KlasaDashboardHooksOptions;
+		clientID?: string;
 		clientSecret?: string;
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -185,6 +185,7 @@ declare module 'discord.js' {
 
 	export interface ClientOptions {
 		dashboardHooks?: KlasaDashboardHooksOptions;
+		clientSecret?: string;
 	}
 
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -115,9 +115,8 @@ declare module 'klasa-dashboard-hooks' {
 		sslOptions?: SecureContextOptions;
 	}
 
-	export interface DashboardClientOptions extends KlasaClientOptions {
-		dashboardHooks?: KlasaDashboardHooksOptions;
-	}
+	// Types are inherited from augmentation
+	export interface DashboardClientOptions extends KlasaClientOptions {}
 
 	export interface KlasaIncomingMessage extends IncomingMessage {
 		originalUrl: string;
@@ -155,10 +154,7 @@ declare module 'klasa-dashboard-hooks' {
 	export interface Constants {
 		OPTIONS: {
 			dashboardHooks: Required<KlasaDashboardHooksOptions>;
-			pieceDefaults: PieceDefaults & {
-				routes: Required<RouteOptions>;
-				middlewares: Required<MiddlewareOptions>;
-			};
+			pieceDefaults: { [P in keyof PieceDefaults]-?: Required<PieceDefaults[P]> };
 		};
 		METHODS_LOWER: string[];
 		RESPONSES: {
@@ -178,4 +174,25 @@ declare module 'klasa-dashboard-hooks' {
 
 //#endregion Types
 
+}
+
+declare module 'discord.js' {
+
+	import { KlasaDashboardHooksOptions, RouteOptions } from 'klasa-dashboard-hooks';
+
+	export interface ClientOptions {
+		dashboardHooks?: KlasaDashboardHooksOptions;
+	}
+
+}
+
+declare module 'klasa' {
+
+	import { RouteOptions, MiddlewareOptions } from 'klasa-dashboard-hooks';
+
+
+	export interface PieceDefaults {
+		routes?: RouteOptions;
+		middlewares?: MiddlewareOptions;
+	}
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -154,7 +154,10 @@ declare module 'klasa-dashboard-hooks' {
 	export interface Constants {
 		OPTIONS: {
 			dashboardHooks: Required<KlasaDashboardHooksOptions>;
-			pieceDefaults: { [P in keyof PieceDefaults]-?: Required<PieceDefaults[P]> };
+			pieceDefaults: {
+				routes: Required<RouteOptions>;
+				middlewares: Required<MiddlewareOptions>;
+			};
 		};
 		METHODS_LOWER: string[];
 		RESPONSES: {


### PR DESCRIPTION
### Description of the PR

This PR modifies `klasa-dashboard-hooks`'s typings to augment the types from `discord.js` and `klasa`, allowing compatibility with other plugins.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Use module augmentations over extended type declarations

### Semver Classification

- [x] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
