### PR TITLE
json: Allow PUT and PATCH to have bodies, parse stream.length to number

### DIFF
--- a/src/middlewares/json.js
+++ b/src/middlewares/json.js
@@ -1,5 +1,6 @@
 const zlib = require('zlib');
 const { Middleware } = require('klasa-dashboard-hooks');
+const BODY_METHODS = ['POST', 'PUT', 'PATCH'];
 
 module.exports = class extends Middleware {
 
@@ -8,7 +9,7 @@ module.exports = class extends Middleware {
 	}
 
 	async run(request) {
-		if (request.method !== 'POST') return;
+		if (!request.method || !BODY_METHODS.includes(request.method)) return;
 
 		const stream = this.contentStream(request);
 		let body = '';
@@ -33,7 +34,7 @@ module.exports = class extends Middleware {
 				break;
 			case 'identity':
 				stream = request;
-				stream.length = length;
+				stream.length = Number(length);
 				break;
 		}
 		return stream;


### PR DESCRIPTION
### Description of the PR

Besides our knowledge with other REST APIs (specially with Discord's), `PATCH` and `PUT` methods also have a body.

Source: https://specs.openstack.org/openstack/api-wg/guidelines/http/methods.html

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Allow `PATCH` and `PUT` requests to have their bodies parsed.
- Fixed request.length being a string instead of a number.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [ ] This PR fixes a bug and does not change the (intended) framework interface.
- [x] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
