### PR TITLE
fix: MiddlewareStore not putting higher priority to the end

### DIFF
--- a/src/lib/structures/MiddlewareStore.js
+++ b/src/lib/structures/MiddlewareStore.js
@@ -41,7 +41,9 @@ class MiddlewareStore extends Store {
 		const middleware = super.set(piece);
 		if (!middleware) return middleware;
 		const index = this.sortedMiddlwares.findIndex(mid => mid.priority >= middleware.priority);
-		this.sortedMiddlwares.splice(index === -1 ? 0 : index, 0, middleware);
+		// If a middleware with lower priority wasn't found, push to the end of the array
+		if (index === -1) this.sortedMiddlwares.push(middleware);
+		else this.sortedMiddlwares.splice(index, 0, middleware);
 		return middleware;
 	}
 


### PR DESCRIPTION
### Description of the PR

When I added a custom middleware with priority 150, I noticed the middlewares were inserted with this order: `[ 150, 10, 20, 100 ]`, because no lower element could be found (index -1) so it was inserted to the very start, causing the wrong order.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Fixed MiddlewareStore pushing to the wrong index on higher priority elements

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
