### PR TITLE
Fix d.js store removal

### DIFF
--- a/src/lib/structures/DashboardGuild.js
+++ b/src/lib/structures/DashboardGuild.js
@@ -99,7 +99,7 @@ class DashboardGuild {
 	 * @readonly
 	 */
 	get guild() {
-		return this.client.guilds.get(this.id) || null;
+		return this.client.guilds.cache.get(this.id) || null;
 	}
 
 	/**

--- a/src/lib/structures/DashboardUser.js
+++ b/src/lib/structures/DashboardUser.js
@@ -102,7 +102,7 @@ class DashboardUser {
 	 * @readonly
 	 */
 	get user() {
-		return this.client.users.get(this.id) || null;
+		return this.client.users.cache.get(this.id) || null;
 	}
 
 	/**

--- a/src/routes/application.js
+++ b/src/routes/application.js
@@ -9,9 +9,9 @@ module.exports = class extends Route {
 
 	get(request, response) {
 		return response.end(JSON.stringify({
-			users: this.client.users.size,
-			guilds: this.client.guilds.size,
-			channels: this.client.channels.size,
+			users: this.client.users.cache.size,
+			guilds: this.client.guilds.cache.size,
+			channels: this.client.channels.cache.size,
 			shards: this.client.options.shardCount,
 			uptime: Duration.toNow(Date.now() - (process.uptime() * 1000)),
 			latency: this.client.ws.ping.toFixed(0),

--- a/src/routes/oauthGuilds.js
+++ b/src/routes/oauthGuilds.js
@@ -11,7 +11,7 @@ module.exports = class extends Route {
 	}
 
 	async post(request, response) {
-		const botGuild = this.client.guilds.get(request.body.id);
+		const botGuild = this.client.guilds.cache.get(request.body.id);
 		const updated = await botGuild.settings.update(request.body.data, { action: 'overwrite' });
 		const errored = Boolean(updated.errors.length);
 


### PR DESCRIPTION
### Description of the PR
The discord.js store removal commit broke dashboardhooks.
I am not sure if there is more to fix, but this made it work again in my case.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

-Fix d.js store removal causing incompatibilities

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
